### PR TITLE
Normalize unicode characters in title and remove colons to prevent errors with N_m3u8DL-RE

### DIFF
--- a/kanopy-downloader.py
+++ b/kanopy-downloader.py
@@ -6,6 +6,7 @@ import re
 import base64
 import os
 import urllib.request
+from unidecode import unidecode
 
 folder_path = f"E:\MEOW"  # Make this a valid path to a folder
 
@@ -16,7 +17,7 @@ subtitles = videoinfo["captions"][0]["files"][1]["url"]
 video_id = json_data['videoId']
 r = requests.get(f'https://www.kanopy.com/kapi/videos/{video_id}', headers=headers, json=json_data)
 video_information = json.loads(r.text)
-title = video_information['video']['title']
+title = (unidecode(video_information['video']['title'])).replace(":", " -")
 year = video_information['video']['productionYear']
 name = f'{title} {year}'
 print(name)

--- a/kanopy-downloader.py
+++ b/kanopy-downloader.py
@@ -19,7 +19,7 @@ r = requests.get(f'https://www.kanopy.com/kapi/videos/{video_id}', headers=heade
 video_information = json.loads(r.text)
 title = (unidecode(video_information['video']['title'])).replace(":", " -")
 year = video_information['video']['productionYear']
-name = f'{title} {year}'
+name = f'{title} ({year})'
 print(name)
 dest_dir = f"{folder_path}/{name}"
 def getsubs():
@@ -58,9 +58,9 @@ try:
         response = requests.post('https://cdrm-project.com/wv', json=json_data)
         result = re.search(r"[a-z0-9]{16,}:[a-z0-9]{16,}", str(response.text))
         decryption_key = result.group()
-        print(decryption_key)
         decryption_key = f'key_id={decryption_key}'
         decryption_key = decryption_key.replace(":", ":key=")
+        print("Decryption Key: " + decryption_key)
         # Download the video using N_m3u8DL-RE
         os.system(
             fr'N_m3u8DL-RE "{manifesturl}" --auto-select --save-name "{name}" --auto-select --save-dir {folder_path} --tmp-dir {folder_path}/temp')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ json
 re
 base64
 urllib
+unidecode


### PR DESCRIPTION
Unicode characters like accented letters in the title string were causing filename saving issues with N_m3u8DL-RE.  To avoid the issue, these characters are normalized to unaccented equivalents.

Colon characters were causing similar issues, and are also not permitted in filenames for some  file systems. Any colons encountered are replaced with " -".